### PR TITLE
RCE fix: use execFile and pass commands as arguments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -725,7 +725,7 @@ f.echo = function (data, callback) {
 f.echo.args = ['data', 'callback'];
 
 f.setDate = function (date, callback) {
-    child_process.exec('date -s "' + date + '"', dateResponse);
+    child_process.execFile('date', ['-s', date], dateResponse)
 
     function dateResponse(error, stdout, stderr) {
         if (typeof callback != 'function') return;


### PR DESCRIPTION
### 📊 Metadata *

BoneScript is a node.js library for physical computing on embedded Linux, starting with support for BeagleBone.

Affected versions of this package are vulnerable to Command Injection. It is possible to inject arbitrary commands by using a semicolon char in the setDate() function.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-bonescript

### ⚙️ Description *

Used `child_process.execFile()` instead of `child_process.exec()`.

### 💻 Technical Description *

The use of the child_process function exec() is highly discouraged if you accept user input and don't sanitize/escape them. I replaced it with execFile() which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *

`var b = require('bonescript');`

`b.setDate('"; touch HACKED; #//', function(error, resp){`
`    console.log(resp);`
`});`

### 🔥 Proof of Fix (PoF) *

Before:

![before](https://user-images.githubusercontent.com/64132745/100216179-fda3a880-2f37-11eb-9e2f-57a4595cede7.png)

After:

![after](https://user-images.githubusercontent.com/64132745/100216406-3e032680-2f38-11eb-8770-646103cdf09c.png)


### 👍 User Acceptance Testing (UAT)

![UAT](https://user-images.githubusercontent.com/64132745/100216619-802c6800-2f38-11eb-978e-2b1d77c0cd2d.png)

